### PR TITLE
Add Next.js Route Handler example demonstrating SmoothAPI resilience

### DIFF
--- a/examples/nextjs/.gitignore
+++ b/examples/nextjs/.gitignore
@@ -1,0 +1,5 @@
+/node_modules
+/.next
+/out
+next-env.d.ts.bak
+*.tsbuildinfo

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,0 +1,105 @@
+# Next.js Example — @codingaryan/smoothapi
+
+A minimal [Next.js](https://nextjs.org/) (App Router, TypeScript) example showing
+how to use `@codingaryan/smoothapi` to make calls to an unreliable third-party
+API resilient. Real upstream services fail intermittently, rate-limit, and go
+down; this example wraps `fetch` with retries, a fallback value, and a circuit
+breaker so your route handlers degrade gracefully instead of erroring out.
+
+It demonstrates two route handlers against the project's chaos **sandbox**
+server:
+
+- `/api/resilient` — retry + fallback against `/unstable-data`.
+- `/api/circuit-demo` — circuit breaker against `/always-fail`.
+
+---
+
+## Prerequisites & Setup
+
+### 1. Start the sandbox server
+
+The example calls the chaos sandbox on `http://localhost:3001`. From the repo
+root:
+
+```bash
+cd sandbox
+npm install
+node server.js
+```
+
+Leave this terminal running.
+
+### 2. Run the example
+
+In a second terminal:
+
+```bash
+cd examples/nextjs
+npm install
+npm run dev
+```
+
+Then open [http://localhost:3000](http://localhost:3000) and use the two buttons,
+or call the routes directly with the curl commands below.
+
+---
+
+## Walkthrough
+
+### `/api/resilient` — retry + fallback
+
+This route points `createResilientFetch` at `/unstable-data`, which returns a
+mix of `200`, `429`, and `500` responses. With the default retry settings, a
+retryable status (`429`/`500`/...) causes the client to back off and try again
+(up to the default number of retries). Because `/unstable-data` never fails
+three times in a row, retries usually recover a `200`.
+
+If every attempt fails, a configured `fallback` value
+(`{ data: 'cached fallback (stale)' }`) is returned instead of throwing. The
+response includes a `source` flag so you can tell where the data came from:
+
+- `"source": "live"` — a real response from the API (with its HTTP `status`).
+- `"source": "fallback"` — the stale cached value was served instead.
+
+In practice you'll almost always see `"source": "live"` here: because `/unstable-data`
+never fails several times back-to-back, the retries recover a `200`. To see the
+`fallback` path actually taken, use `/api/circuit-demo` below. Note also that the
+route passes `{ cache: 'no-store' }` so Next.js doesn't cache the response and
+hide the API's varying behavior.
+
+The route also sets `onNonRetryableError` to a `console.error` logger so the
+library does **not** fall back to its browser `alert()` behavior on the server.
+
+### `/api/circuit-demo` — circuit breaker
+
+This route points `createResilientFetch` at `/always-fail`, which always returns
+`500`, with `failureThreshold: 3` and a short `cooldownMs` so the demo is quick.
+
+Call it repeatedly and watch the behavior change:
+
+1. **First call(s)** — the request hits the network and retries each `500`.
+   Consecutive failures accumulate and, once the threshold is reached, the
+   circuit trips **OPEN**. The response reports `"hitNetwork": true`.
+2. **Subsequent calls** — while the circuit is OPEN, requests are
+   short-circuited to the `fallback` *without making any network request*. The
+   response reports `"hitNetwork": false`.
+3. **After the cooldown** — the breaker probes again (HALF_OPEN); since
+   `/always-fail` is still down, it re-opens.
+
+The breaker counts **consecutive** failures and **resets on success**. That's
+why `/unstable-data` can never trip it (a `200` always clears the count), while
+`/always-fail` trips it reliably.
+
+---
+
+## Example requests
+
+```bash
+# Retry + fallback demo
+curl http://localhost:3000/api/resilient
+
+# Circuit breaker demo — run it several times in a row to see the circuit open
+curl http://localhost:3000/api/circuit-demo
+curl http://localhost:3000/api/circuit-demo
+curl http://localhost:3000/api/circuit-demo
+```

--- a/examples/nextjs/app/api/circuit-demo/route.ts
+++ b/examples/nextjs/app/api/circuit-demo/route.ts
@@ -1,0 +1,45 @@
+import { createResilientFetch } from '@codingaryan/smoothapi';
+
+// This route makes a live request on every call, so opt out of static
+// prerendering at build time.
+export const dynamic = 'force-dynamic';
+
+const SANDBOX_URL = 'http://localhost:3001/always-fail';
+
+const FALLBACK = { data: 'circuit-open fallback' };
+
+// Module-scoped so the breaker state survives across requests. /always-fail
+// never succeeds, so consecutive failures accumulate until the circuit trips.
+const resilientFetch = createResilientFetch<typeof FALLBACK>({
+  retryOn: [429, 500, 502, 503, 504],
+  circuitBreaker: {
+    failureThreshold: 3,
+    cooldownMs: 5000, // short cooldown so the demo recovers quickly
+  },
+  fallback: FALLBACK,
+  onNonRetryableError: (status, message) => {
+    console.error(`[circuit-demo] non-retryable ${status}: ${message}`);
+  },
+});
+
+export async function GET() {
+  // no-store: bypass Next.js's default fetch cache so every call is a real
+  // request — otherwise the breaker would never see repeated failures.
+  const result = await resilientFetch(SANDBOX_URL, { cache: 'no-store' });
+
+  // A Response means the request reached the network (and retried). The
+  // fallback object means the OPEN circuit short-circuited before any IO.
+  if (result instanceof Response) {
+    return Response.json({
+      hitNetwork: true,
+      behavior: 'retried against the API, then returned the upstream response',
+      status: result.status,
+    });
+  }
+
+  return Response.json({
+    hitNetwork: false,
+    behavior: 'circuit OPEN — instant fallback, no network request made',
+    data: result,
+  });
+}

--- a/examples/nextjs/app/api/resilient/route.ts
+++ b/examples/nextjs/app/api/resilient/route.ts
@@ -1,0 +1,39 @@
+import { createResilientFetch } from '@codingaryan/smoothapi';
+
+// This route makes a live request on every call, so opt out of static
+// prerendering at build time.
+export const dynamic = 'force-dynamic';
+
+const SANDBOX_URL = 'http://localhost:3001/unstable-data';
+
+// Fallback payload returned when the API can't be reached. Typing it here lets
+// the result be discriminated from a real Response below.
+const FALLBACK = { data: 'cached fallback (stale)' };
+
+// Created once at module scope so the circuit-breaker state is shared across
+// requests instead of being reset on every call.
+const resilientFetch = createResilientFetch<typeof FALLBACK>({
+  // Keep the default backoff/retry settings.
+  retryOn: [429, 500, 502, 503, 504],
+  fallback: FALLBACK,
+  fallbackOnNonRetryable: true,
+  // Server-side: log instead of the browser-alert default.
+  onNonRetryableError: (status, message) => {
+    console.error(`[resilient] non-retryable ${status}: ${message}`);
+  },
+});
+
+export async function GET() {
+  // no-store: Next.js caches fetch() by default, which would hide the
+  // unstable API's varying responses. We want a live call every time.
+  const result = await resilientFetch(SANDBOX_URL, { cache: 'no-store' });
+
+  // A Response means we reached the network; the fallback object means we
+  // returned the stale cached value instead.
+  if (result instanceof Response) {
+    const data = await result.json().catch(() => null);
+    return Response.json({ source: 'live', status: result.status, data });
+  }
+
+  return Response.json({ source: 'fallback', data: result });
+}

--- a/examples/nextjs/app/layout.tsx
+++ b/examples/nextjs/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'smoothapi Next.js example',
+  description: 'Resilient fetch demo against the chaos sandbox',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/nextjs/app/page.tsx
+++ b/examples/nextjs/app/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function Home() {
+  const [output, setOutput] = useState<string>('Click a button to call a route.');
+
+  async function call(path: string) {
+    setOutput('Loading...');
+    try {
+      const res = await fetch(path);
+      const json = await res.json();
+      setOutput(JSON.stringify(json, null, 2));
+    } catch (err) {
+      setOutput(`Request failed: ${String(err)}`);
+    }
+  }
+
+  return (
+    <main style={{ fontFamily: 'monospace', padding: 24 }}>
+      <h1>smoothapi Next.js example</h1>
+      <p>Make sure the sandbox server is running on http://localhost:3001.</p>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={() => call('/api/resilient')}>Call /api/resilient</button>
+        <button onClick={() => call('/api/circuit-demo')}>Call /api/circuit-demo</button>
+      </div>
+      <pre style={{ marginTop: 16, padding: 12, background: '#f0f0f0' }}>{output}</pre>
+    </main>
+  );
+}

--- a/examples/nextjs/next-env.d.ts
+++ b/examples/nextjs/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/examples/nextjs/next.config.mjs
+++ b/examples/nextjs/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "smoothapi-nextjs-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Next.js App Router example for @codingaryan/smoothapi",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@codingaryan/smoothapi": "1.0.0",
+    "next": "14.2.35",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "typescript": "5.4.5"
+  }
+}

--- a/examples/nextjs/tsconfig.json
+++ b/examples/nextjs/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/sandbox/server.js
+++ b/sandbox/server.js
@@ -34,10 +34,15 @@ app.get('/reset', (_req, res) => {
 //       3   0       500
 //       5       0   429
 //       6   0       500
-//       9   0       500   <-- circuit threshold hit (3 consecutive 500s)
+//       9   0       500
 //      10       0   429
 //      12   0       500
 //      15   0   0   500
+//
+// Note: the failures are spaced out by 200s, never 3-in-a-row. A circuit
+// breaker that resets its failure count on every success (as ours does) will
+// therefore never trip against this endpoint — each 500/429 is followed by a
+// 200 that clears the counter. Use /always-fail to exercise the breaker.
 //
 app.get('/unstable-data', (_req, res) => {
   requestCount++;
@@ -56,6 +61,13 @@ app.get('/unstable-data', (_req, res) => {
 
   console.log(`[sandbox]   200`);
   return res.status(200).json({ success: true, data: 'Solid Data' });
+});
+
+// Always 500. Unlike /unstable-data, this never succeeds, so consecutive
+// failures accumulate and trip a circuit breaker. Does not touch requestCount.
+app.get('/always-fail', (_req, res) => {
+  console.log(`[sandbox] /always-fail -> 500`);
+  return res.status(500).json({ error: 'Service Unavailable' });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Add Next.js Route Handler example demonstrating SmoothAPI resilience

Closes #3.

Adds a minimal Next.js (App Router, TypeScript) example under `examples/nextjs` showing SmoothAPI wrapping unreliable third-party calls in a server-side context, using the existing sandbox as the failing API. Scope was agreed in #3 / Discord: focused on a Route Handler, retry + fallback + circuit breaker shown live, `onNonRetryableError` logging instead of the browser alert.

### What's included

**`examples/nextjs/`**
- `app/api/resilient/route.ts` — `createResilientFetch` against `/unstable-data`. Demonstrates retries on transient errors (429/500/…) and the fallback path. Returns a `source: 'live' | 'fallback'` flag.
- `app/api/circuit-demo/route.ts` — `createResilientFetch` against the new `/always-fail`, `failureThreshold: 3`, short cooldown. Demonstrates the breaker opening, short-circuiting IO, and recovering after cooldown.
- `app/page.tsx` — minimal UI with a button per route showing the raw JSON.
- `README.md` — setup, walkthrough of both routes, and curl examples. Notes that the breaker counts consecutive failures and resets on success.
- Pinned deps; uses the published `@codingaryan/smoothapi@1.0.0`.

**`sandbox/server.js`**
- Added `GET /always-fail` (always 500), needed for a deterministic breaker demo.
- Fixed the comment on `/unstable-data`: the 500s at req 3/6/9 aren't consecutive (200s fall between them), so they can't trip a breaker that resets on success — the old comment implied they would.

### Why `/always-fail` was needed

Reading `state.ts`, the breaker counts *consecutive* failures and `recordSuccess` resets the count. `/unstable-data` never returns 3 failures in a row, so it can't trip the breaker. `/unstable-data` is perfect for the retry/fallback demo; `/always-fail` gives a deterministic path to show the breaker actually opening.

### Verified end to end

Against the running sandbox:

`/api/resilient` — retries visible (one route call → multiple sandbox hits, e.g. req#5 429 → req#6 500 → req#7 200, recovered), `source` flag correct.

`/api/circuit-demo` — breaker lifecycle confirmed:
```
call 1: hitNetwork=true,  500     <- retried, trips breaker
call 2-5: hitNetwork=false        <- instant fallback, zero network IO
[wait > cooldown]
probe: hitNetwork=true, 500       <- HALF_OPEN probe fails
next:  hitNetwork=false           <- re-OPEN
```
Sandbox logged exactly the network hits expected and none during the open state — the breaker genuinely short-circuits IO.

### Two deltas worth flagging

Both confined to `examples/nextjs/`, both required for the demo to actually work under Next:
- `{ cache: 'no-store' }` on the fetches + `export const dynamic = 'force-dynamic'` on both routes — without these, Next caches the fetch and prerenders the routes at build time, so repeated calls don't reach the sandbox and the build fails against an offline sandbox.
- Bumped `next` 14.2.5 → 14.2.35 (security advisory on the original pin).

### Notes
- No library packages were touched.
- `tsc --noEmit` clean; `next build` clean with both routes dynamic.

Happy to adjust anything — scope, structure, or wording.