### PR TITLE
fix: Runtime warning for deprecated createResilientFetch

### DIFF
--- a/packages/smooth-api-ts/src/index.ts
+++ b/packages/smooth-api-ts/src/index.ts
@@ -155,4 +155,11 @@ export function createSmoothFetch<T>(globalConfig: SmoothFetchConfig<T>) {
 }
 
 /** @deprecated use createSmoothFetch instead */
-export const createResilientFetch = createSmoothFetch;
+export const createResilientFetch = (...args: Parameters<typeof createSmoothFetch>) => {
+  if (typeof console !== "undefined" && console.warn) {
+    console.warn(
+      "[smoothAPI] createResilientFetch is deprecated; use createSmoothFetch instead.",
+    );
+  }
+  return createSmoothFetch(...args);
+};


### PR DESCRIPTION
## Summary

Runtime warning for deprecated createResilientFetch

## Changes

- createResilientFetch: runtime deprecation warning wrapping createSmoothFetch

Fixes #25
