### PR TITLE
feat: add request deduplication demo to Express example

### DIFF
--- a/examples/express/README.md
+++ b/examples/express/README.md
@@ -7,6 +7,7 @@ This example demonstrates how to integrate SmoothAPI into an Express.js applicat
 - Automatic retries for transient failures
 - Circuit breaker protection
 - Graceful fallback responses
+- Request deduplication for concurrent identical requests
 - Express.js integration using SmoothAPI
 
 ---
@@ -96,6 +97,17 @@ GET http://localhost:3001/always-fail
 
 After repeated failures, the circuit breaker opens and returns the configured fallback response immediately without making another network request.
 
+### GET /dedup-demo
+
+Demonstrates SmoothAPI's request deduplication by making three identical
+requests concurrently using `Promise.all()`.
+
+All three requests target the same sandbox URL:
+
+```text
+GET http://localhost:3001/health
+```
+
 ---
 
 ## Example Requests
@@ -106,6 +118,7 @@ You can test the endpoints with curl:
 curl http://localhost:3002/health
 curl http://localhost:3002/retry-demo
 curl http://localhost:3002/circuit-demo
+curl http://localhost:3002/dedup-demo
 ```
 
 Or you could open the endpoints on any browser

--- a/examples/express/server.ts
+++ b/examples/express/server.ts
@@ -45,16 +45,21 @@ const customSmoothFetch = createSmoothFetch({
         timeoutMs: 5000
 });
 
+const dedupSmoothFetch = createSmoothFetch({
+    deduplication: {}
+});
+
 app.use(express.json());
 
 app.get('/', (_req, res) => {
     // The root endpoint of the example express server.
     res.json({ 
         message: 'Welcome to the SmoothAPI Express Example!',
-        description: 'Demonstrates retries, circuit breakers, and fallback handling using SmoothAPI.',
+        description: 'Demonstrates retries, circuit breakers, fallback handling, and request deduplication using SmoothAPI.',
         endpoints: {
             retry_demo: '/retry-demo',
             circuit_demo: '/circuit-demo',
+            dedup_demo: '/dedup-demo',
         },
     });
 });
@@ -107,6 +112,31 @@ app.get('/circuit-demo', async (_req, res) => {
         // (strictly speaking, this won't happen in this example since the upstream always fails)
         const data = await result.json().catch(() => null);
         return res.json({ source: 'upstream-response', status: result.status, data });
+    } catch (error) {
+        return res.status(502).json({
+            error: error instanceof Error ? error.message : String(error),
+        });
+    }
+});
+
+app.get('/dedup-demo', async (_req, res) => {
+    try {
+        const [response1, response2, response3] = await Promise.all([
+            dedupSmoothFetch(`${SANDBOX_URL}/health`),
+            dedupSmoothFetch(`${SANDBOX_URL}/health`),
+            dedupSmoothFetch(`${SANDBOX_URL}/health`),
+        ]);
+
+        const [data1, data2, data3] = await Promise.all([
+            response1.json(),
+            response2.json(),
+            response3.json(),
+        ]);
+
+        return res.json({
+            message: 'Three identical requests were made concurrently.',
+            results: [data1, data2, data3],
+        });
     } catch (error) {
         return res.status(502).json({
             error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary

- Add a `/dedup-demo` endpoint to the Express example
- Enable SmoothAPI request deduplication
- Make three identical requests concurrently using `Promise.all()`
- Return the results to the client
- Document the new endpoint in the Express example README

## Testing

- `npm run build`
- `npm test`
- Manually tested `/dedup-demo`
- Verified that three concurrent identical requests result in a single underlying sandbox request

Closes #29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Express example endpoint demonstrating request deduplication with concurrent identical health requests.
  * The endpoint returns the parsed results from all concurrent requests.

* **Documentation**
  * Updated the Express example documentation with request deduplication details and a curl example for the new endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->